### PR TITLE
Prevent Prototype Pollution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const isInteger = (val: any): boolean => Number(val) == val && Number(val) % 1 =
 const isNumeric = (val: any): boolean => !isArray(val) && (val - parseFloat(val) + 1) >= 0;
 const isData = (data: any): boolean => isObj(data) || isArray(data);
 const isArrayKey = (key: DotKey): boolean => isInteger(key) && parseInt(<string>key) >= 0;
+const isValidKey  = (key: DotKey): boolean => key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
 const hasProp = (obj: any, key: DotKey) => obj && obj.hasOwnProperty(key);
 const objKeys = Object.keys;
 
@@ -102,7 +103,8 @@ export const tokenize = (str: string): Tokens => {
 
   splitTokens(str).forEach(token => {
     token.replace(regex.prop, (m: any, n: number, q: string, s: string): any => {
-      results.push(q ? s.replace(regex.escape, '$1') : (n || m));
+      const t = q ? s.replace(regex.escape, '$1') : (n || m);
+      if (isValidKey(t)) results.push(t);
     });
   });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -41,7 +41,10 @@ describe('dot-wild', () => {
     assert.deepStrictEqual(dot.tokenize('foo**bar'), ['foo**bar']);
     assert.deepStrictEqual(dot.tokenize('hoge.1.fuga'), ['hoge', '1', 'fuga']);
     assert.deepStrictEqual(dot.tokenize('hoge[1].fuga'), ['hoge', '1', 'fuga']);
-    assert.deepStrictEqual(dot.tokenize('hoge[1].*.fuga'), ['hoge', '1', '*', 'fuga']);
+    assert.deepStrictEqual(dot.tokenize('__proto__.polluted'), ['polluted']);
+    assert.deepStrictEqual(dot.tokenize('prototype.polluted'), ['polluted']);
+    assert.deepStrictEqual(dot.tokenize('constructor.polluted'), ['polluted']);
+    assert.deepStrictEqual(dot.tokenize('[\'__proto__\'].polluted'), ['polluted']);
   });
 
 


### PR DESCRIPTION
This package has security issue of [Prototype Pollution](https://github.com/Kirill89/prototype-pollution-explained) that is the vulnerability of JavaScript. (#18)

In this PR, prevent Prototype Pollution by prohibiting access to `__proto__` , `prototype` and `constructor` .
